### PR TITLE
Fix for pointer events `pen` input in Edge/IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Since the form fields `input` and `textarea` rely on the keyboard as their only 
 <body data-whatinput-formtyping>
 ```
 
+Where present, Pointer Events are supported, but note that `pen` inputs are remapped to `touch`.
+
 What Input also exposes a tiny API that allows the developer to ask for or set the current input.
 
 _What Input does not make assumptions about the input environment before the user makes their first interaction._

--- a/what-input.js
+++ b/what-input.js
@@ -47,7 +47,9 @@
     'mouseenter': 'mouse',
     'touchstart': 'touch',
     'pointerdown': 'pointer',
-    'MSPointerDown': 'pointer'
+    'pointerenter': 'pointer',
+    'MSPointerDown': 'pointer',
+    'MSPointerEnter': 'pointer'
   };
 
   // array of all used input types
@@ -142,7 +144,11 @@
   }
 
   function pointerType(event) {
-    return (typeof event.pointerType === 'number') ? pointerMap[event.pointerType] : event.pointerType;
+    if (typeof event.pointerType === 'number') {
+      return pointerMap[event.pointerType];
+    } else {
+      return (event.pointerType === 'pen') ? 'touch' : event.pointerType; // treat pen like touch
+    }
   }
 
   // keyboard logging
@@ -158,24 +164,22 @@
   }
 
   function bindEvents() {
-
-    // pointer/mouse
-    var mouseEvent = 'mousedown';
-
+    // pointer events (mouse, pen, touch)
     if (window.PointerEvent) {
-      mouseEvent = 'pointerdown';
+      body.addEventListener('pointerdown', immediateInput);
+      body.addEventListener('pointerenter', immediateInput);
     } else if (window.MSPointerEvent) {
-      mouseEvent = 'MSPointerDown';
+      body.addEventListener('MSPointerDown', immediateInput);
+      body.addEventListener('MSPointerEnter', immediateInput);
+    } else {
+      // mouse events
+      body.addEventListener('mousedown', immediateInput);
+      body.addEventListener('mouseenter', immediateInput);
+      // touch events
+      if ('ontouchstart' in window) {
+        body.addEventListener('touchstart', bufferInput);
+      }
     }
-
-    body.addEventListener(mouseEvent, immediateInput);
-    body.addEventListener('mouseenter', immediateInput);
-
-    // touch
-    if ('ontouchstart' in window) {
-      body.addEventListener('touchstart', bufferInput);
-    }
-
     // keyboard
     body.addEventListener('keydown', immediateInput);
     document.addEventListener('keyup', unLogKeys);


### PR DESCRIPTION
Remapping of "pen" to "touch" now also implemented (fairly naively, admittedly) for Edge/IE11 (where `event.pointerType` is NOT a number, so previously wasn't being remapped at all and resulted in a value of "pen" for `data-what-input`). Additionally, this also now registers `pointerenter`, as otherwise pen interactions keep flipping back to being recognised as `mouse` when the pen is moving over the page (due to the compatibility mouse events being fired for `pointerenter`)
