### PR TITLE
Extend buffer timeout

### DIFF
--- a/what-input.js
+++ b/what-input.js
@@ -98,7 +98,7 @@
     buffer = true;
     timer = setTimeout(function() {
       buffer = false;
-    }, 300);
+    }, 650);
   }
 
   function bufferedEvent(event) {


### PR DESCRIPTION
300ms is causing iOS (which has default delay of ~350ms) to trigger touch, then mouse (once mouse compatibility events fire). through trial and error (on iPhone 6S) a value of around 650ms seems more appropriate (and still snappier than the original 1s from previous version)
