### PR TITLE
Change readme to encourage more responsible removal of focus states

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ What Input will start doing its thing while you do yours.
   border-color: blue;
 }
 ```
-**note:** If you remove outlines with `outline: none;`, be sure to provide clear visual `:focus` styles so the user can see which element they are on at any time for greater accessibility.
+**note:** If you remove outlines with `outline: none;`, be sure to provide clear visual `:focus` styles so the user can see which element they are on at any time for greater accessibility. Visit [W3C's WCAG 2.0 2.4.7 Guideline](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html) to learn more.
 
 ### Scripting
 

--- a/README.md
+++ b/README.md
@@ -68,21 +68,29 @@ What Input will start doing its thing while you do yours.
 
 ```css
 /**
- * set a default :focus style
+ * set a custom default :focus style
  */
 :focus {
-  outline: 3px dotted #06c;
+  outline: none;
+  border: dotted 2px black;
 }
 
-/*
- * remove :focus style via What Input using progressive enhancement
- * so :focus isn't left broken if JavaScript fails
- */
-[data-whatinput="mouse"] :focus,
-[data-whatinput="touch"] :focus {
-  outline: none;
+/* mouse */
+[data-whatinput='mouse'] :focus {
+  border-color: red;
+}
+
+/* keyboard */
+[data-whatinput='keyboard'] :focus {
+  border-color: green;
+}
+
+/* touch */
+[data-whatinput='touch'] :focus {
+  border-color: blue;
 }
 ```
+**note:** If you remove outlines with `outline: none;`, be sure to provide clear visual `:focus` styles so the user can see which element they are on at any time for greater accessibility.
 
 ### Scripting
 


### PR DESCRIPTION
@ten1seven As mentioned in #17 Here is a PR that addresses accessibility concerns raised.

Per your [demo](http://ten1seven.github.io/what-input/) you do an awesome job of not removing focus state by providing different focus states. There isn't ever an opportunity to have no focus state. While I personally struggle with why a keyboard user needs an alternate visual focus state -- the pattern you offer here is a more responsible way of handling `:focus` state.

The original `readme` suggested global removal of outlines in your **Example Styling** section (sad clown):

``` css
[data-whatinput="mouse"] :focus,
[data-whatinput="touch"] :focus {
  outline: none;
}
```

I understand your code snippet was purely an example, but in a world where more novice developers copy/paste code snippets for production code I feel it is important that these snippets set them up for success! :)

I've taken `CSS` straight from your [demo](http://ten1seven.github.io/what-input/) and altered it just a bit and added it to the `readme` as it provides a quick visual/code example of what your plugin does without potentially harming accessibility. [CodePen demo](http://codepen.io/joe-watkins/pen/WxRMpp)

``` css
/* mouse */
[data-whatinput='mouse'] :focus {
  border-color: red;
}

/* keyboard */
[data-whatinput='keyboard'] :focus {
  border-color: green;
}

/* touch */
[data-whatinput='touch'] :focus {
  border-color: blue;
}
```

Focus states are such awesome free built-in accessibility features that are worth more than most developers give them credit for. The idea here with this PR is to still prove the functionality of the plugin while maintaining accessibility best practices.

If the author chooses to make a poor decision by removing outlines that is on them. :)
