### PR TITLE
fixed main file path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Jeremy Fields <jeremy.fields@viget.com>"
   ],
   "description": "A global utility for tracking the current input method (mouse, keyboard or touch).",
-  "main": "what-input.js",
+  "main": "dist/what-input.js",
   "keywords": [
     "accessibility",
     "a11y",


### PR DESCRIPTION
fixed main file path to dist/what-input.js as what-input.js is no longer on the root level.  Without this, my project's gulpfile is not able to automatically inject the what-input.js dependency into my html file.
