### PR TITLE
Remove 'button' from the list of form inputs

### DIFF
--- a/src/what-input.js
+++ b/src/what-input.js
@@ -17,7 +17,6 @@ module.exports = (function() {
 
   // form input types
   var formInputs = [
-    'button',
     'input',
     'select',
     'textarea'


### PR DESCRIPTION
Refers to #43.
Buttons can be used as versatile element for interactive content and are not necessarily an indication for a form context.
