### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.2.7",
   "description": "A global utility for tracking the current input method (mouse, keyboard or touch).",
   "main": "dist/what-input.js",
+  "types": "src/scripts/what-input.d.ts",
   "repository": {
     "url": "https://github.com/ten1seven/what-input.git",
     "type": "git"

--- a/src/scripts/what-input.d.ts
+++ b/src/scripts/what-input.d.ts
@@ -1,0 +1,14 @@
+declare module "what-input" {
+  export interface WhatInput {
+    ask: (strategy?: "intent") => "pointer" | "keyboard" | "mouse" | "touch";
+    element: () => string | null;
+    ignoreKeys: (keyCodes: number[]) => void;
+    specificKeys: (keyCodes: number[]) => void;
+    registerOnChange: (callback: () => void, strategy?: "intent") => void;
+    unRegisterOnChange: (callback: () => void) => void;
+    clearStorage: () => void;
+  }
+
+  const whatInput: WhatInput;
+  export default whatInput;
+}

--- a/src/scripts/what-input.d.ts
+++ b/src/scripts/what-input.d.ts
@@ -1,14 +1,12 @@
-declare module "what-input" {
-  export interface WhatInput {
-    ask: (strategy?: "intent") => "pointer" | "keyboard" | "mouse" | "touch";
-    element: () => string | null;
-    ignoreKeys: (keyCodes: number[]) => void;
-    specificKeys: (keyCodes: number[]) => void;
-    registerOnChange: (callback: () => void, strategy?: "intent") => void;
-    unRegisterOnChange: (callback: () => void) => void;
-    clearStorage: () => void;
-  }
-
-  const whatInput: WhatInput;
-  export default whatInput;
+export interface WhatInput {
+  ask: (strategy?: "intent") => "pointer" | "keyboard" | "mouse" | "touch";
+  element: () => string | null;
+  ignoreKeys: (keyCodes: number[]) => void;
+  specificKeys: (keyCodes: number[]) => void;
+  registerOnChange: (callback: () => void, strategy?: "intent") => void;
+  unRegisterOnChange: (callback: () => void) => void;
+  clearStorage: () => void;
 }
+
+const whatInput: WhatInput;
+export default whatInput;


### PR DESCRIPTION
### Adds TypeScript types!

- Allows TS projects to use this package without having to provide types or use `@ts-ignore`
- Adds autocomplete support to editors that support TS
- Enables type warnings when bad values are passed or methods are being used improperly. 

#### Autocomplete in VS Code 
![typed-autocomplete](https://user-images.githubusercontent.com/647549/81876196-162a1380-9550-11ea-96b3-2705d791a4f6.gif)

#### TypeScript error highlighting
![typed2](https://user-images.githubusercontent.com/647549/81876036-c21f2f00-954f-11ea-82a3-13cf54d3131c.gif)
