### PR TITLE
Update what-input.d.ts

### DIFF
--- a/src/scripts/what-input.d.ts
+++ b/src/scripts/what-input.d.ts
@@ -1,4 +1,4 @@
-export interface WhatInput {
+declare const whatInput: {
   ask: (strategy?: "intent") => "pointer" | "keyboard" | "mouse" | "touch";
   element: () => string | null;
   ignoreKeys: (keyCodes: number[]) => void;
@@ -6,7 +6,6 @@ export interface WhatInput {
   registerOnChange: (callback: () => void, strategy?: "intent") => void;
   unRegisterOnChange: (callback: () => void) => void;
   clearStorage: () => void;
-}
+};
 
-const whatInput: WhatInput;
 export default whatInput;


### PR DESCRIPTION
Resolves the following warning:

> Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

![fix](https://user-images.githubusercontent.com/647549/81974268-5393ad00-95f3-11ea-9303-e6506e830fea.gif)

**Sorry I missed this the first go-round!** 

The definition file did work fine prior to this - the warning just showed up if you looked at the file directly. I'm still learning the ins and outs of TypeScript. Loving it though!
