### PR TITLE
fix: improve types

### DIFF
--- a/src/scripts/what-input.d.ts
+++ b/src/scripts/what-input.d.ts
@@ -1,11 +1,15 @@
 declare const whatInput: {
-  ask: (strategy?: "intent") => "pointer" | "keyboard" | "mouse" | "touch";
+  ask: (strategy?: Strategy) => InputMethod;
   element: () => string | null;
   ignoreKeys: (keyCodes: number[]) => void;
   specificKeys: (keyCodes: number[]) => void;
-  registerOnChange: (callback: () => void, strategy?: "intent") => void;
-  unRegisterOnChange: (callback: () => void) => void;
+  registerOnChange: (callback: (type: InputMethod) => void, strategy?: Strategy) => void;
+  unRegisterOnChange: (callback: (type: InputMethod) => void) => void;
   clearStorage: () => void;
 };
+
+export type InputMethod = "initial" | "pointer" | "keyboard" | "mouse" | "touch";
+
+export type Strategy = "input" | "intent";
 
 export default whatInput;


### PR DESCRIPTION
Resolves #109.

This will allow importing of the additional types. For testing, this is now valid TS:
```ts
import whatInput, { InputMethod, Strategy } from 'what-input';

const handleInputChange = (type: InputMethod) => {
  console.log(type);
};
whatInput.registerOnChange(handleInputChange, 'intent');
whatInput.unRegisterOnChange(handleInputChange);

const getInputMethod = (strategy: Strategy) => {
  return whatInput.ask(strategy);
};
```